### PR TITLE
fix: handle optional CSS loader options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,12 +58,12 @@ export const pluginTypedCSSModules = (
               continue;
             }
 
-            const cssLoaderOptions: CSSLoaderOptions = rule
+            const cssLoaderOptions = rule
               .use(CHAIN_ID.USE.CSS)
-              .get('options');
+              .get('options') as CSSLoaderOptions | undefined;
 
             if (
-              !cssLoaderOptions.modules ||
+              !cssLoaderOptions?.modules ||
               (typeof cssLoaderOptions.modules === 'object' &&
                 cssLoaderOptions.modules.auto === false)
             ) {


### PR DESCRIPTION
## Summary

- type the copied CSS loader options through rspack-chain generic loader options
- skip rules without configured CSS loader options
- restore compatibility with the stricter rspack-chain getter types exposed by Rsbuild

## Validation

- pnpm lint
- pnpm check
- pnpm build
- pnpm test (10 passed)

Related: web-infra-dev/rsbuild#8437